### PR TITLE
fix: translation typo

### DIFF
--- a/po/zh_TW/broadcasting.po
+++ b/po/zh_TW/broadcasting.po
@@ -958,7 +958,7 @@ msgstr "window.Echo = new Echo({\n"
 
 #: docs/8.x/broadcasting.md:block 159 (header)
 msgid "Customizing The Authorization Request"
-msgstr "自訂授權 Endpoint"
+msgstr "自訂授權請求"
 
 #: docs/8.x/broadcasting.md:block 160 (paragraph)
 msgid "You can customize how Laravel Echo performs authorization requests by providing a custom authorizer when initializing Echo:"


### PR DESCRIPTION
"Customizing The Authorization Request" was translated wrong as "自訂授權 Endpoint".

英文不好，所以用中文再打一次：
「Customizing The Authorization Request」被錯誤翻譯成「自訂授權 Endpoint」（應該是不小心和前一個標題重複沒修改到），這邊參考內文重新翻譯成「自訂授權請求」